### PR TITLE
feat: dark mode with theme toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,6 +138,16 @@
     }
   </style>
 
+  <!-- Dark mode anti-flash: apply theme class before first paint -->
+  <script>
+    (function() {
+      var t = localStorage.getItem('theme');
+      if (t === 'dark' || (!t && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+        document.documentElement.classList.add('dark');
+      }
+    })();
+  </script>
+
   <!-- Favicon -->
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 
@@ -208,7 +218,7 @@
 
 </head>
 
-<body class="text-violet min-h-screen">
+<body class="text-violet dark:text-beige dark:bg-dark-bg min-h-screen transition-colors duration-300">
   <div id="root"></div>
   <script type="module" src="/src/main.tsx"></script>
 </body>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,8 @@ import { Routes, Route } from "react-router-dom";
 import ScrollToTopOnRouteChange from "./components/common/scroll-to-top-on-route-change";
 import ErrorBoundary from "./components/common/error-boundary";
 import SeoHead from "./components/common/seo-head";
+import ThemeToggle from "./components/common/theme-toggle";
+import { useTheme } from "./hooks/use-theme";
 const HomePage = lazy(() => import("./pages/home-page"));
 const LegalNotice = lazy(() => import("./pages/legal-notice"));
 const PrivacyPolicy = lazy(() => import("./pages/privacy-policy"));
@@ -11,11 +13,14 @@ const ProjectDetail = lazy(() => import("./pages/project-detail"));
 const NotFound = lazy(() => import("./pages/not-found"));
 
 const App: React.FC = () => {
+	const { theme, toggleTheme } = useTheme();
+
 	return (
 		<ErrorBoundary>
 			<SeoHead />
 			<ScrollToTopOnRouteChange />
-			<Suspense fallback={<div className="min-h-screen flex items-center justify-center bg-beige text-violet">Loading...</div>}>
+			<ThemeToggle theme={theme} toggleTheme={toggleTheme} />
+			<Suspense fallback={<div className="min-h-screen flex items-center justify-center bg-beige dark:bg-dark-bg text-violet dark:text-beige">Loading...</div>}>
 				<Routes>
 					<Route path="/" element={<HomePage />} />
 					<Route path="/projet/:projectId" element={<ProjectDetail />} />

--- a/src/components/common/bottom-blur.tsx
+++ b/src/components/common/bottom-blur.tsx
@@ -2,7 +2,7 @@ export default function BottomBlur() {
 	return (
 		<div className="pointer-events-none fixed bottom-0 left-0 w-full h-[26vh] z-20">
 			<div
-				className="w-full h-full backdrop-blur-2xl bg-violet/20"
+				className="w-full h-full backdrop-blur-2xl bg-violet/20 dark:bg-dark-bg/40"
 				style={{
 					maskImage: "linear-gradient(to top, black, transparent)",
 					WebkitMaskImage: "linear-gradient(to top, black, transparent)",

--- a/src/components/common/floating-language-switcher.tsx
+++ b/src/components/common/floating-language-switcher.tsx
@@ -25,8 +25,10 @@ const FloatingLanguageSwitcher: React.FC = () => {
           fixed top-4 right-4 sm:top-6 sm:right-6 z-[99999]
           flex items-center gap-2 px-2 py-1 sm:px-3 sm:py-2 rounded-full
           bg-gradient-to-br from-lime/20 via-orange/10 to-violet/5
-          backdrop-blur-md border border-lime/30 text-violet
-          hover:bg-lime hover:text-orange font-sans font-bold text-xs sm:text-sm uppercase tracking-wider
+          dark:from-lime/10 dark:via-orange/5 dark:to-violet/10
+          backdrop-blur-md border border-lime/30 dark:border-lime/20 text-violet dark:text-beige
+          hover:bg-lime hover:text-orange dark:hover:bg-lime/20 dark:hover:text-lime
+          font-sans font-bold text-xs sm:text-sm uppercase tracking-wider
           ${TRANSITIONS.DEFAULT} shadow-lg hover:shadow-xl
           active:scale-95 transition-transform duration-150
           focus:outline-none focus:ring-2 focus:ring-orange focus:ring-offset-2
@@ -52,7 +54,8 @@ const FloatingLanguageSwitcher: React.FC = () => {
               fixed top-16 right-4 sm:top-20 sm:right-6 z-[99998]
               w-32 sm:w-36 rounded-2xl shadow-2xl
               bg-gradient-to-br from-lime/20 via-orange/10 to-violet/5
-              backdrop-blur-md border border-lime/30
+              dark:from-lime/10 dark:via-orange/5 dark:to-violet/10
+              backdrop-blur-md border border-lime/30 dark:border-lime/20
             `}
             role="listbox"
             aria-label="Language options"
@@ -66,7 +69,7 @@ const FloatingLanguageSwitcher: React.FC = () => {
                   onClick={() => handleLanguageChange(language.code)}
                   className={`
                     w-full px-3 py-3 sm:px-4 text-left flex items-center gap-2 sm:gap-3
-                    text-violet hover:bg-lime hover:text-orange ${TRANSITIONS.DEFAULT}
+                    text-violet dark:text-beige hover:bg-lime hover:text-orange dark:hover:bg-lime/20 dark:hover:text-lime ${TRANSITIONS.DEFAULT}
                     ${isSelected ? 'bg-orange/10 font-bold' : 'font-medium'}
                     focus:outline-none focus:bg-orange/20 text-xs sm:text-sm
                     first:rounded-t-xl last:rounded-b-xl active:scale-95 transition-transform duration-150

--- a/src/components/common/modal-notice.tsx
+++ b/src/components/common/modal-notice.tsx
@@ -22,15 +22,16 @@ export default function ModalNotice({ show, onClose }: ModalNoticeProps) {
 					initial={{ opacity: 0 }}
 					animate={{ opacity: 1 }}
 					exit={{ opacity: 0 }}
-					className="fixed inset-0 bg-beige/40 backdrop-blur-sm flex items-center justify-center z-[9999]"
+					className="fixed inset-0 bg-beige/40 dark:bg-dark-bg/60 backdrop-blur-sm flex items-center justify-center z-[9999]"
 				>
 					<motion.div
 						initial={{ y: -50, opacity: 0 }}
 						animate={{ y: 0, opacity: 1 }}
 						exit={{ y: -50, opacity: 0 }}
-						className="w-full max-w-md mx-4 p-6 text-violet text-center
+						className="w-full max-w-md mx-4 p-6 text-violet dark:text-beige text-center
 						bg-gradient-to-br from-lime/20 via-orange/10 to-violet/5
-						backdrop-blur-md border border-lime/30 rounded-2xl shadow-md
+						dark:from-lime/10 dark:via-orange/5 dark:to-violet/10
+						backdrop-blur-md border border-lime/30 dark:border-lime/20 rounded-2xl shadow-md
 						transition-all duration-300 ease-[cubic-bezier(0.83,0,0.17,1)]"
 					>
 						<h3 className="text-3xl font-display font-extrabold mb-4">

--- a/src/components/common/scroll-to-top.tsx
+++ b/src/components/common/scroll-to-top.tsx
@@ -28,8 +28,10 @@ export default function ScrollToTop() {
 			className={`fixed bottom-6 right-6 z-[9999] flex items-center gap-2
         px-4 py-2 sm:px-6 sm:py-3 rounded-full font-bold
         bg-gradient-to-br from-lime/20 via-orange/10 to-violet/5
-        backdrop-blur-md border border-lime/30 text-violet
-        hover:bg-lime hover:text-orange font-sans uppercase tracking-wider text-sm
+        dark:from-lime/10 dark:via-orange/5 dark:to-violet/10
+        backdrop-blur-md border border-lime/30 dark:border-lime/20 text-violet dark:text-beige
+        hover:bg-lime hover:text-orange dark:hover:bg-lime/20 dark:hover:text-lime
+        font-sans uppercase tracking-wider text-sm
         transition-all duration-300 ease-in-out
         focus:outline focus:outline-2 focus:outline-offset-2 focus:outline-orange
         active:scale-95

--- a/src/components/common/theme-toggle.tsx
+++ b/src/components/common/theme-toggle.tsx
@@ -1,0 +1,52 @@
+import type React from "react";
+import { useTranslation } from "react-i18next";
+import { motion, AnimatePresence } from "framer-motion";
+import { FaSun, FaMoon } from "react-icons/fa";
+
+interface ThemeToggleProps {
+	theme: "light" | "dark";
+	toggleTheme: () => void;
+}
+
+const ThemeToggle: React.FC<ThemeToggleProps> = ({ theme, toggleTheme }) => {
+	const { t } = useTranslation("common");
+	const isDark = theme === "dark";
+
+	return (
+		<button
+			type="button"
+			onClick={toggleTheme}
+			className="
+				fixed top-4 left-4 sm:top-6 sm:left-6 z-[99999]
+				flex items-center justify-center w-9 h-9 sm:w-10 sm:h-10 rounded-full
+				bg-gradient-to-br from-lime/20 via-orange/10 to-violet/5
+				dark:from-lime/10 dark:via-orange/5 dark:to-violet/10
+				backdrop-blur-md border border-lime/30 dark:border-lime/20
+				text-violet dark:text-beige
+				hover:bg-lime hover:text-orange dark:hover:bg-lime/20 dark:hover:text-lime
+				font-sans font-bold text-sm
+				transition-all duration-300 shadow-lg hover:shadow-xl
+				active:scale-95
+				focus:outline-none focus:ring-2 focus:ring-orange focus:ring-offset-2
+				dark:focus:ring-offset-dark-bg
+			"
+			aria-label={isDark ? t("theme.switchToLight") : t("theme.switchToDark")}
+		>
+			<AnimatePresence mode="wait" initial={false}>
+				<motion.span
+					key={theme}
+					initial={{ rotate: -90, opacity: 0, scale: 0.5 }}
+					animate={{ rotate: 0, opacity: 1, scale: 1 }}
+					exit={{ rotate: 90, opacity: 0, scale: 0.5 }}
+					transition={{ duration: 0.2, ease: "easeOut" }}
+					className="flex items-center justify-center"
+					aria-hidden="true"
+				>
+					{isDark ? <FaSun className="w-4 h-4 sm:w-5 sm:h-5" /> : <FaMoon className="w-4 h-4 sm:w-5 sm:h-5" />}
+				</motion.span>
+			</AnimatePresence>
+		</button>
+	);
+};
+
+export default ThemeToggle;

--- a/src/components/effects/layered-icon-background.tsx
+++ b/src/components/effects/layered-icon-background.tsx
@@ -30,7 +30,7 @@ export default function LayeredIconBackground({
 			{LAYERS.map((layer) => (
 				<motion.div
 					key={layer.id}
-					className="absolute text-lime"
+					className="absolute text-lime dark:text-lime/60"
 					initial={{
 						scale: layer.scale,
 						opacity: layer.opacity,

--- a/src/components/effects/profile-background.tsx
+++ b/src/components/effects/profile-background.tsx
@@ -74,7 +74,7 @@ export default function ProfileBackground() {
 			{layers.map((layer) => (
 				<motion.div
 					key={layer.id}
-					className="absolute text-lime"
+					className="absolute text-lime dark:text-lime/60"
 					initial={{
 						scale: layer.scale,
 						opacity: layer.opacity,

--- a/src/components/effects/smile-grid.tsx
+++ b/src/components/effects/smile-grid.tsx
@@ -83,7 +83,7 @@ const SmileGrid: React.FC<SmileGridProps> = ({ active }) => {
 							setSmiles((prev) => prev.filter((s) => s.id !== smile.id))
 						}
 					>
-						<SmileIcon className="text-lime w-full h-full" />
+						<SmileIcon className="text-lime dark:text-lime/60 w-full h-full" />
 					</motion.div>
 				))}
 			</AnimatePresence>

--- a/src/components/layout/background-gradient.tsx
+++ b/src/components/layout/background-gradient.tsx
@@ -6,14 +6,27 @@ export default function BackgroundGradient() {
 			className="fixed inset-0 z-[-10] overflow-hidden pointer-events-none"
 			aria-hidden="true"
 		>
-			{/* Moving gradient */}
+			{/* Moving gradient — light mode */}
 			<motion.div
-				className="absolute inset-0 bg-[length:300%_300%] animate-gradient-move"
+				className="absolute inset-0 bg-[length:300%_300%] animate-gradient-move dark:opacity-0 transition-opacity duration-500"
 				style={{
 					backgroundImage: `
             radial-gradient(at 20% 30%, #ffefc1 0%, transparent 60%),
             radial-gradient(at 80% 80%, #e2a788 0%, transparent 60%),
             linear-gradient(135deg, #c4817f, #fef3c7, #b28d6e)
+          `,
+					backgroundBlendMode: "overlay, soft-light, normal",
+					willChange: "background-position",
+				}}
+			/>
+			{/* Moving gradient — dark mode */}
+			<motion.div
+				className="absolute inset-0 bg-[length:300%_300%] animate-gradient-move opacity-0 dark:opacity-100 transition-opacity duration-500"
+				style={{
+					backgroundImage: `
+            radial-gradient(at 20% 30%, rgba(105,0,255,0.15) 0%, transparent 60%),
+            radial-gradient(at 80% 80%, rgba(181,255,0,0.08) 0%, transparent 60%),
+            linear-gradient(135deg, #0F0A1A, #1A1230, #0F0A1A)
           `,
 					backgroundBlendMode: "overlay, soft-light, normal",
 					willChange: "background-position",

--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -12,7 +12,7 @@ const FOOTER_NAV = [
 export default function Footer() {
 	const { t } = useTranslation('common');
 	return (
-		<footer className="relative w-full bg-lime text-violet-dark pt-8 pb-40 px-6 md:px-10 text-center">
+		<footer className="relative w-full bg-lime dark:bg-dark-surface text-violet-dark dark:text-beige pt-8 pb-40 px-6 md:px-10 text-center">
 			<h2 className="text-2xl font-display font-extrabold mb-6 flex flex-wrap justify-center gap-x-2" style={{ fontVariationSettings: '"opsz" 144, "SOFT" 0, "WONK" 0' }}>
 				<LetterRippleEffect text="Josué " />
 				<LetterRippleEffect text="Rocha" />
@@ -28,9 +28,9 @@ export default function Footer() {
 					</a>
 				))}
 			</nav>
-			<p className="text-sm italic text-violet-dark mb-6">{t('footer.craftedWith')}</p>
-			<div className="w-16 h-px bg-violet-dark/20 mx-auto mb-6" />
-			<div className="flex justify-center gap-4 mb-2 text-xs text-violet-dark">
+			<p className="text-sm italic text-violet-dark dark:text-beige/70 mb-6">{t('footer.craftedWith')}</p>
+			<div className="w-16 h-px bg-violet-dark/20 dark:bg-beige/20 mx-auto mb-6" />
+			<div className="flex justify-center gap-4 mb-2 text-xs text-violet-dark dark:text-beige/70">
 				<Link
 					to="/mentions-legales"
 					className="hover:text-orange transition-colors underline"
@@ -45,7 +45,7 @@ export default function Footer() {
 					{t('footer.privacy')}
 				</Link>
 			</div>
-			<p className="text-xs text-violet-dark">
+			<p className="text-xs text-violet-dark dark:text-beige/60">
 				© {new Date().getFullYear()} Josué Rocha. {t('footer.allRights')}
 			</p>
 		</footer>

--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -46,7 +46,7 @@ const Navbar: React.FC = () => {
 			ref={navRef}
 			onMouseMove={handleMouseMove}
 			aria-label="Main navigation"
-			className="relative w-full bg-transparent backdrop-blur-md text-violet font-bold text-sm sm:text-lg uppercase tracking-wider font-sans overflow-hidden py-4 sm:py-6 z-50 border-b-2 border-lime"
+			className="relative w-full bg-transparent backdrop-blur-md text-violet dark:text-beige font-bold text-sm sm:text-lg uppercase tracking-wider font-sans overflow-hidden py-4 sm:py-6 z-50 border-b-2 border-lime dark:border-lime/40"
 		>
 			{/* Animated bars background */}
 			<div className="absolute inset-0 z-[1]">
@@ -60,7 +60,7 @@ const Navbar: React.FC = () => {
 						return (
 							<div
 								key={`bar-${i}`}
-								className="animated-bar absolute top-0 h-full bg-lime backdrop-blur-md transition-[width,opacity] duration-100 ease-[cubic-bezier(0.83,0,0.17,1)]"
+								className="animated-bar absolute top-0 h-full bg-lime dark:bg-lime/30 backdrop-blur-md transition-[width,opacity] duration-100 ease-[cubic-bezier(0.83,0,0.17,1)]"
 								style={{ left, width: '0px', opacity: 0 }}
 							/>
 						);
@@ -74,7 +74,7 @@ const Navbar: React.FC = () => {
 					<li>
 						<a
 							href="#hero"
-							className="transition-colors duration-200 text-violet hover:text-orange focus:outline-none focus:ring-2 focus:ring-orange focus:ring-offset-2 rounded-lg"
+							className="transition-colors duration-200 text-violet dark:text-beige hover:text-orange focus:outline-none focus:ring-2 focus:ring-orange focus:ring-offset-2 dark:focus:ring-offset-dark-bg rounded-lg"
 							aria-label="Home"
 						>
 							<SmileIcon className="w-8 h-8 sm:w-10 sm:h-10" />
@@ -90,7 +90,7 @@ const Navbar: React.FC = () => {
 								initial="initial"
 								animate="initial"
 								whileHover="hover"
-								className="inline-block cursor-pointer focus:outline-none focus:ring-2 focus:ring-orange focus:ring-offset-2 rounded px-1 py-1 sm:px-2 text-xs sm:text-base"
+								className="inline-block cursor-pointer focus:outline-none focus:ring-2 focus:ring-orange focus:ring-offset-2 dark:focus:ring-offset-dark-bg rounded px-1 py-1 sm:px-2 text-xs sm:text-base"
 							>
 								{t(`navigation.${key}`)}
 							</motion.a>

--- a/src/components/layout/page-layout.tsx
+++ b/src/components/layout/page-layout.tsx
@@ -25,7 +25,7 @@ const PageLayout: React.FC<Props> = ({
 	};
 
 	const content = (
-		<div className="min-h-screen text-violet">
+		<div className="min-h-screen text-violet dark:text-beige">
 			<BackgroundGradient />
 			<main className={`relative z-10 ${maxWidthClasses[maxWidth]} mx-auto px-6 py-20 ${className}`} role="main">
 				{children}

--- a/src/components/sections/bio.tsx
+++ b/src/components/sections/bio.tsx
@@ -14,11 +14,11 @@ export default function Bio() {
 	return (
 		<section
 			id="bio"
-			className="relative z-10 w-full px-6 py-20 text-violet"
+			className="relative z-10 w-full px-6 py-20 text-violet dark:text-beige"
 		>
 			<div className="max-w-6xl mx-auto flex flex-col items-start">
 					<FadeInUpOnScroll delay={0.2}>
-					<h2 className="relative w-full px-4 text-[clamp(2rem,7vw,6rem)] leading-[1.1] font-display font-extrabold text-violet text-left flex flex-wrap gap-x-2">
+					<h2 className="relative w-full px-4 text-[clamp(2rem,7vw,6rem)] leading-[1.1] font-display font-extrabold text-violet dark:text-beige text-left flex flex-wrap gap-x-2">
 						{t('heading').split(" ").map((word) => (
 							<LetterRippleEffect key={word} text={`${word} `} />
 						))}
@@ -45,10 +45,10 @@ export default function Bio() {
 					{Object.entries(sections).map(([key, section], i) => (
 						<FadeInUpOnScroll key={key} delay={0.2 + i * 0.15}>
 							<div className="relative min-h-[120px]">
-								<h3 className="text-2xl font-serif font-bold text-violet mb-2 capitalize">
+								<h3 className="text-2xl font-serif font-bold text-violet dark:text-beige mb-2 capitalize">
 									{section.title}
 								</h3>
-								<p className="text-base md:text-lg leading-relaxed text-violet">
+								<p className="text-base md:text-lg leading-relaxed text-violet dark:text-beige/90">
 									{section.text}
 								</p>
 								<LayeredIconBackground

--- a/src/components/sections/bio/timeline.tsx
+++ b/src/components/sections/bio/timeline.tsx
@@ -71,7 +71,8 @@ function TimelineStep({
 					transition={{ duration: 0.6, ease: [0.65, 0, 0.35, 1] }}
 					className="
 						bg-gradient-to-br from-lime/20 via-orange/10 to-violet/5
-						backdrop-blur-md border border-lime/30 rounded-2xl shadow-md
+						dark:from-lime/10 dark:via-orange/5 dark:to-violet/10
+						backdrop-blur-md border border-lime/30 dark:border-lime/20 rounded-2xl shadow-md
 						px-5 md:px-6 py-4 md:py-5
 						flex flex-col justify-center
 						hover:shadow-lg hover:scale-[1.01]
@@ -81,10 +82,10 @@ function TimelineStep({
 					<span className="text-xs md:text-sm font-display font-semibold text-orange/70 tracking-wide uppercase mb-1">
 						{step.period}
 					</span>
-					<h3 className="text-lg md:text-xl lg:text-2xl font-extrabold font-display leading-snug text-violet">
+					<h3 className="text-lg md:text-xl lg:text-2xl font-extrabold font-display leading-snug text-violet dark:text-beige">
 						{step.title}
 					</h3>
-					<p className="text-sm md:text-base leading-relaxed text-violet/80 mt-3">
+					<p className="text-sm md:text-base leading-relaxed text-violet/80 dark:text-beige/70 mt-3">
 						{step.text}
 					</p>
 				</motion.article>
@@ -184,10 +185,10 @@ export default function Timeline() {
 	return (
 		<div className="relative z-0 w-full">
 			{/* Year picker — horizontal, sticky on scroll */}
-			<nav aria-label="Timeline navigation" className="sticky top-4 sm:top-6 z-20 ml-4 md:ml-0 w-fit rounded-full flex items-center gap-2 px-2 py-1 sm:px-3 sm:py-2 bg-gradient-to-br from-lime/20 via-orange/10 to-violet/5 backdrop-blur-md border border-lime/30 shadow-lg hover:shadow-xl hover:bg-lime active:scale-95 transition-transform duration-150 mb-6">
+			<nav aria-label="Timeline navigation" className="sticky top-4 sm:top-6 z-20 ml-4 md:ml-0 w-fit rounded-full flex items-center gap-2 px-2 py-1 sm:px-3 sm:py-2 bg-gradient-to-br from-lime/20 via-orange/10 to-violet/5 dark:from-lime/10 dark:via-orange/5 dark:to-violet/10 backdrop-blur-md border border-lime/30 dark:border-lime/20 shadow-lg hover:shadow-xl hover:bg-lime dark:hover:bg-lime/20 active:scale-95 transition-transform duration-150 mb-6">
 				{years.map((year, i) => (
 					<React.Fragment key={year}>
-						{i > 0 && <span className="text-violet/20 text-xs select-none" aria-hidden="true">&bull;</span>}
+						{i > 0 && <span className="text-violet/20 dark:text-beige/20 text-xs select-none" aria-hidden="true">&bull;</span>}
 						<button
 							type="button"
 							onClick={() => handleYearClick(i)}
@@ -196,7 +197,7 @@ export default function Timeline() {
 								transition-all duration-300 cursor-pointer active:scale-95
 								${i === activeIndex
 									? "text-orange"
-									: "text-violet hover:text-orange-dark"
+									: "text-violet dark:text-beige hover:text-orange-dark dark:hover:text-orange"
 								}
 							`}
 						>

--- a/src/components/sections/contact.tsx
+++ b/src/components/sections/contact.tsx
@@ -32,24 +32,26 @@ export default function Contact() {
 			className="relative px-6 pt-32 pb-56 min-h-[80vh] text-center overflow-hidden"
 		>
 			{/* LIGHT STRIP BOTTOM */}
-			<div className="absolute bottom-0 left-0 w-full h-12 bg-lime opacity-60 blur-2xl z-[1] pointer-events-none" />
+			<div className="absolute bottom-0 left-0 w-full h-12 bg-lime dark:bg-lime/40 opacity-60 dark:opacity-30 blur-2xl z-[1] pointer-events-none" />
 
 			{/* HAND SVG */}
-			<motion.img
-				src={handImage}
-				alt={t('contact.handAlt')}
-				className="absolute bottom-0 left-0 w-full max-w-[1400px] h-auto z-0 pointer-events-none select-none pb-24"
-				initial={{ opacity: 0, y: 100 }}
-				whileInView={{ opacity: 1, y: 0 }}
-				style={{ willChange: "transform" }}
-				transition={{ duration: 1.2, ease: [0.6, 0.05, 0.01, 0.99] }}
-				viewport={{ once: true, amount: 0.3 }}
-				loading="lazy"
-			/>
+			<div className="absolute bottom-0 left-0 w-full z-0 pointer-events-none dark:opacity-20 transition-opacity duration-300">
+				<motion.img
+					src={handImage}
+					alt={t('contact.handAlt')}
+					className="w-full max-w-[1400px] h-auto select-none pb-24"
+					initial={{ opacity: 0, y: 100 }}
+					whileInView={{ opacity: 1, y: 0 }}
+					style={{ willChange: "transform" }}
+					transition={{ duration: 1.2, ease: [0.6, 0.05, 0.01, 0.99] }}
+					viewport={{ once: true, amount: 0.3 }}
+					loading="lazy"
+				/>
+			</div>
 
 			{/* TITLE */}
 			<FadeInUpOnScroll delay={0.2}>
-				<h2 className="relative z-10 text-[clamp(2rem,6vw,5rem)] leading-tight font-display font-extrabold text-violet flex flex-wrap justify-center gap-x-2">
+				<h2 className="relative z-10 text-[clamp(2rem,6vw,5rem)] leading-tight font-display font-extrabold text-violet dark:text-beige flex flex-wrap justify-center gap-x-2">
 					{t('contact.heading').split(" ").map((word) => (
 						<LetterRippleEffect key={word} text={`${word} `} />
 					))}
@@ -58,8 +60,8 @@ export default function Contact() {
 
 			{/* CARD */}
 			<FadeInUpOnScroll delay={0.4}>
-				<div className="relative z-10 max-w-xl mx-auto mt-8 bg-gradient-to-br from-lime/20 via-orange/10 to-violet/5 backdrop-blur-md border border-lime/30 rounded-2xl shadow-md p-8">
-					<p className="text-base sm:text-lg text-violet leading-relaxed mb-6">
+				<div className="relative z-10 max-w-xl mx-auto mt-8 bg-gradient-to-br from-lime/20 via-orange/10 to-violet/5 dark:from-lime/10 dark:via-orange/5 dark:to-violet/10 backdrop-blur-md border border-lime/30 dark:border-lime/20 rounded-2xl shadow-md p-8">
+					<p className="text-base sm:text-lg text-violet dark:text-beige leading-relaxed mb-6">
 						{t('contact.description')}
 					</p>
 					<div className="flex gap-4 flex-wrap justify-center">
@@ -69,8 +71,9 @@ export default function Contact() {
 								href={href}
 								target={href.startsWith("mailto") ? undefined : "_blank"}
 								rel="noopener noreferrer"
-								className="px-4 py-2 rounded-full bg-orange/10 text-orange-dark border border-orange/20
-								hover:bg-orange hover:text-beige transition-all duration-300
+								className="px-4 py-2 rounded-full bg-orange/10 text-orange-dark dark:text-orange border border-orange/20
+								hover:bg-orange hover:text-beige dark:hover:bg-orange/20 dark:hover:text-orange
+								transition-all duration-300
 								inline-flex items-center gap-2 font-medium text-sm
 								hover:shadow-md hover:scale-105 active:scale-95"
 								aria-label={`Link to ${label.toLowerCase()}`}

--- a/src/components/sections/hero.tsx
+++ b/src/components/sections/hero.tsx
@@ -18,13 +18,13 @@ const Hero: React.FC = () => {
 	return (
 		<section
 			id="hero"
-			className="relative flex flex-col min-h-[calc(100vh-6rem)] px-6 pt-12 pb-10 text-violet overflow-hidden"
+			className="relative flex flex-col min-h-[calc(100vh-6rem)] px-6 pt-12 pb-10 text-violet dark:text-beige overflow-hidden"
 		>
 			<SmileGrid active={showSmiles} />
 
 			{/* LIGHT STRIP simplified for LCP */}
 			<div
-				className="absolute top-0 left-0 w-full h-12 bg-lime blur-2xl z-0 pointer-events-none"
+				className="absolute top-0 left-0 w-full h-12 bg-lime dark:bg-lime/40 blur-2xl z-0 pointer-events-none"
 				style={{ opacity: lightOn ? 0.6 : 0, transition: lightOn ? "opacity 1s ease-out" : "none" }}
 			/>
 

--- a/src/components/sections/projects.tsx
+++ b/src/components/sections/projects.tsx
@@ -21,19 +21,21 @@ export default function Projects() {
 		<section
 			id="projects"
 			ref={sectionRef}
-			className="relative w-full px-6 py-20 text-violet overflow-hidden"
+			className="relative w-full px-6 py-20 text-violet dark:text-beige overflow-hidden"
 		>
 
-			<motion.div
-				className="absolute top-[100px] right-[-200px] w-[1600px] h-[1600px] z-0 pointer-events-none"
-				style={{ rotate: rotation }}
-			>
-				<SunIcon className="w-full h-full" />
-			</motion.div>
+			<div className="absolute top-[100px] right-[-200px] w-[1600px] h-[1600px] z-0 pointer-events-none dark:opacity-[0.15] transition-opacity duration-300">
+				<motion.div
+					className="w-full h-full"
+					style={{ rotate: rotation }}
+				>
+					<SunIcon className="w-full h-full" />
+				</motion.div>
+			</div>
 
 			<div className="max-w-6xl mx-auto flex flex-col gap-20 relative z-10">
 				<FadeInUpOnScroll delay={0.2}>
-					<h2 className="relative max-w-6xl mx-auto px-4 text-[clamp(2rem,7vw,7rem)] leading-[1.1] font-display font-extrabold text-violet text-center flex flex-wrap justify-left gap-x-2">
+					<h2 className="relative max-w-6xl mx-auto px-4 text-[clamp(2rem,7vw,7rem)] leading-[1.1] font-display font-extrabold text-violet dark:text-beige text-center flex flex-wrap justify-left gap-x-2">
 						{t('heading')
 							.split(" ")
 							.map((word, i) => (
@@ -61,7 +63,8 @@ i}`}
 							<article
 								className="w-full flex flex-col lg:flex-row gap-6 items-start
 								bg-gradient-to-br from-lime/20 via-orange/10 to-violet/5
-								backdrop-blur-md border border-lime/30 rounded-2xl shadow-md p-6
+								dark:from-lime/10 dark:via-orange/5 dark:to-violet/10
+								backdrop-blur-md border border-lime/30 dark:border-lime/20 rounded-2xl shadow-md p-6
 								hover:shadow-lg hover:scale-[1.01]
 								transition-all duration-300 ease-[cubic-bezier(0.83,0,0.17,1)]"
 							>
@@ -89,8 +92,9 @@ i}`}
 									<p className="text-base">{projectTranslations?.context || project.context}</p>
 									<Link
 										to={`/projet/${project.id}`}
-										className="mt-6 px-4 py-2 rounded-full bg-orange/10 text-orange-dark border border-orange/20
-										hover:bg-orange hover:text-beige transition-all duration-300 
+										className="mt-6 px-4 py-2 rounded-full bg-orange/10 text-orange-dark dark:text-orange border border-orange/20
+										hover:bg-orange hover:text-beige dark:hover:bg-orange/20 dark:hover:text-orange
+										transition-all duration-300
 										inline-flex items-center gap-2 self-start font-medium text-sm
 										hover:shadow-md hover:scale-105 active:scale-95"
 										aria-label={`${t('labels.seeMore')} ${projectTranslations?.title || project.title}`}

--- a/src/components/sections/skills.tsx
+++ b/src/components/sections/skills.tsx
@@ -11,32 +11,32 @@ interface SkillCategory {
 const SKILL_CATEGORIES: SkillCategory[] = [
 	{
 		label: "mainframe",
-		color: "bg-violet text-beige",
+		color: "bg-violet text-beige dark:bg-violet/60 dark:text-beige",
 		skills: ["COBOL", "JCL", "z/OS", "TSO/ISPF", "DB2/SQL", "CICS", "VSAM"],
 	},
 	{
 		label: "frontend",
-		color: "bg-lime text-violet-dark",
+		color: "bg-lime text-violet-dark dark:bg-lime/20 dark:text-lime",
 		skills: ["React", "TypeScript", "Next.js", "Tailwind CSS", "Framer Motion", "Vite"],
 	},
 	{
 		label: "backend",
-		color: "bg-orange text-violet-dark",
+		color: "bg-orange text-violet-dark dark:bg-orange/20 dark:text-orange",
 		skills: ["Node.js", "Express", "PostgreSQL", "Sequelize", "Prisma", "FastAPI"],
 	},
 	{
 		label: "tools",
-		color: "bg-violet/20 text-violet",
+		color: "bg-violet/20 text-violet dark:bg-violet/30 dark:text-beige",
 		skills: ["Git", "Docker", "Vitest", "Playwright", "Jest", "CI/CD", "Swagger"],
 	},
 	{
 		label: "ai",
-		color: "bg-violet/20 text-violet",
+		color: "bg-violet/20 text-violet dark:bg-violet/30 dark:text-beige",
 		skills: ["Python", "OpenAI API", "RAG", "LangChain", "Langfuse"],
 	},
 	{
 		label: "languages",
-		color: "bg-violet/20 text-violet",
+		color: "bg-violet/20 text-violet dark:bg-violet/30 dark:text-beige",
 		skills: [],
 	},
 ];
@@ -59,7 +59,7 @@ export default function Skills() {
 		>
 			<div className="max-w-6xl mx-auto">
 				<FadeInUpOnScroll delay={0.2}>
-					<h2 className="w-full px-4 text-[clamp(2rem,7vw,6rem)] leading-[1.1] font-display font-extrabold text-violet text-left flex flex-wrap gap-x-2">
+					<h2 className="w-full px-4 text-[clamp(2rem,7vw,6rem)] leading-[1.1] font-display font-extrabold text-violet dark:text-beige text-left flex flex-wrap gap-x-2">
 						{t("heading").split(" ").map((word) => (
 							<LetterRippleEffect key={word} text={`${word} `} />
 						))}
@@ -70,7 +70,7 @@ export default function Skills() {
 					{categories.map((cat, i) => (
 						<FadeInUpOnScroll key={cat.label} delay={0.4 + i * 0.1}>
 							<div className="flex flex-col gap-3">
-								<h3 className="text-lg font-bold text-violet uppercase tracking-wider">
+								<h3 className="text-lg font-bold text-violet dark:text-beige uppercase tracking-wider">
 									{cat.label}
 								</h3>
 								<div className="flex flex-wrap gap-2">

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -29,13 +29,13 @@ export const ANIMATION = {
 export const COLORS = {
 	VIOLET: {
 		BG: "bg-violet",
-		TEXT: "text-violet",
+		TEXT: "text-violet dark:text-beige",
 		BORDER: "border-violet",
 		HOVER_TEXT: "hover:text-violet",
 	},
 	ORANGE: {
-		BG: "bg-orange", 
-		TEXT: "text-orange-dark",
+		BG: "bg-orange",
+		TEXT: "text-orange-dark dark:text-orange",
 		BORDER: "border-orange",
 		HOVER_TEXT: "hover:text-orange",
 	},
@@ -46,17 +46,17 @@ export const COLORS = {
 		HOVER_TEXT: "hover:text-lime",
 	},
 	VARIANTS: {
-		VIOLET_DARK: "text-violet-dark",
-		VIOLET_80: "text-violet/80",
-		VIOLET_70: "text-violet/70", 
-		VIOLET_90: "text-violet/90",
+		VIOLET_DARK: "text-violet-dark dark:text-beige",
+		VIOLET_80: "text-violet/80 dark:text-beige/70",
+		VIOLET_70: "text-violet/70 dark:text-beige/60",
+		VIOLET_90: "text-violet/90 dark:text-beige/80",
 		LIME_20: "bg-lime/20",
 		LIME_30: "border-lime/30",
 	},
 	HIGH_CONTRAST: {
-		VIOLET_ON_LIGHT: "text-violet-dark",
-		TEXT_MUTED: "text-gray-600",
-		TEXT_SECONDARY: "text-gray-700",
+		VIOLET_ON_LIGHT: "text-violet-dark dark:text-beige",
+		TEXT_MUTED: "text-gray-600 dark:text-gray-400",
+		TEXT_SECONDARY: "text-gray-700 dark:text-gray-300",
 	},
 } as const;
 

--- a/src/hooks/use-theme.ts
+++ b/src/hooks/use-theme.ts
@@ -1,0 +1,57 @@
+import { useEffect, useState, useCallback } from "react";
+
+type Theme = "light" | "dark";
+
+const STORAGE_KEY = "theme";
+
+function getInitialTheme(): Theme {
+	if (typeof window === "undefined") return "light";
+
+	const stored = localStorage.getItem(STORAGE_KEY);
+	if (stored === "dark" || stored === "light") return stored;
+
+	return window.matchMedia("(prefers-color-scheme: dark)").matches
+		? "dark"
+		: "light";
+}
+
+function applyTheme(theme: Theme) {
+	const root = document.documentElement;
+	if (theme === "dark") {
+		root.classList.add("dark");
+	} else {
+		root.classList.remove("dark");
+	}
+	// Update meta theme-color for mobile browsers
+	const meta = document.querySelector('meta[name="theme-color"]');
+	if (meta) {
+		meta.setAttribute("content", theme === "dark" ? "#0F0A1A" : "#6900FF");
+	}
+}
+
+export function useTheme() {
+	const [theme, setTheme] = useState<Theme>(getInitialTheme);
+
+	useEffect(() => {
+		applyTheme(theme);
+		localStorage.setItem(STORAGE_KEY, theme);
+	}, [theme]);
+
+	// Listen for OS preference changes (only when no explicit choice stored)
+	useEffect(() => {
+		const mq = window.matchMedia("(prefers-color-scheme: dark)");
+		const handler = (e: MediaQueryListEvent) => {
+			if (!localStorage.getItem(STORAGE_KEY)) {
+				setTheme(e.matches ? "dark" : "light");
+			}
+		};
+		mq.addEventListener("change", handler);
+		return () => mq.removeEventListener("change", handler);
+	}, []);
+
+	const toggleTheme = useCallback(() => {
+		setTheme((prev) => (prev === "dark" ? "light" : "dark"));
+	}, []);
+
+	return { theme, toggleTheme } as const;
+}

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -32,6 +32,10 @@
     "refreshPage": "Refresh page"
   },
   "videoNotSupported": "Your browser does not support videos.",
+  "theme": {
+    "switchToDark": "Switch to dark mode",
+    "switchToLight": "Switch to light mode"
+  },
   "accessibility": {
     "skipToMain": "Skip to main content",
     "closePhoto": "Close photo",

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -32,6 +32,10 @@
     "refreshPage": "Actualiser la page"
   },
   "videoNotSupported": "Votre navigateur ne supporte pas les vidéos.",
+  "theme": {
+    "switchToDark": "Passer en mode sombre",
+    "switchToLight": "Passer en mode clair"
+  },
   "accessibility": {
     "skipToMain": "Aller au contenu principal",
     "closePhoto": "Fermer la photo",

--- a/src/i18n/locales/pt/common.json
+++ b/src/i18n/locales/pt/common.json
@@ -32,6 +32,10 @@
     "refreshPage": "Atualizar página"
   },
   "videoNotSupported": "Seu navegador não suporta vídeos.",
+  "theme": {
+    "switchToDark": "Mudar para modo escuro",
+    "switchToLight": "Mudar para modo claro"
+  },
   "accessibility": {
     "skipToMain": "Pular para o conteúdo principal",
     "closePhoto": "Fechar foto",

--- a/src/index.css
+++ b/src/index.css
@@ -10,12 +10,23 @@ body {
   overflow-x: hidden;
 }
 
+/* Dark mode base */
+.dark body {
+  @apply text-beige;
+  background-color: #0F0A1A;
+}
+
 /* === BUTTONS === */
 .button {
   @apply px-8 py-3 rounded-full font-bold inline-flex items-center transition-all duration-300;
   @apply bg-gradient-to-br from-lime/20 via-orange/10 to-violet/5;
   @apply backdrop-blur-md border border-lime/30 text-violet;
   @apply hover:bg-lime hover:text-orange font-sans uppercase tracking-wider text-sm;
+}
+.dark .button {
+  @apply from-lime/10 via-orange/5 to-violet/10;
+  @apply border-lime/20 text-beige;
+  @apply hover:bg-lime/20 hover:text-lime;
 }
 .button:active {
   transform: scale(0.95);
@@ -49,6 +60,18 @@ button:focus-visible {
   font-weight: 700;
   color: #6900FF;
   text-align: center;
+}
+.dark .funky-title {
+  color: #F5F0E8;
+}
+
+/* === FOCUS DARK MODE === */
+.dark :focus-visible {
+  outline-color: #FF7A00;
+}
+.dark a:focus-visible,
+.dark button:focus-visible {
+  outline-color: #FF7A00;
 }
 
 /* === ANIMATIONS & PERFORMANCE === */

--- a/src/pages/home-page.tsx
+++ b/src/pages/home-page.tsx
@@ -49,7 +49,7 @@ const HomePage: React.FC = () => {
 					<SectionErrorBoundary sectionName="Hero">
 						<Hero />
 					</SectionErrorBoundary>
-					<Suspense fallback={<div className="min-h-[50vh] flex items-center justify-center"><div className="text-violet">Loading...</div></div>}>
+					<Suspense fallback={<div className="min-h-[50vh] flex items-center justify-center"><div className="text-violet dark:text-beige">Loading...</div></div>}>
 						<SectionErrorBoundary sectionName="Bio">
 							<Bio />
 						</SectionErrorBoundary>

--- a/src/pages/legal-notice.tsx
+++ b/src/pages/legal-notice.tsx
@@ -9,7 +9,7 @@ export default function LegalNotice() {
 	const { t } = useTranslation(['legal', 'common']);
 	
 	return (
-		<div className="min-h-screen text-violet-dark">
+		<div className="min-h-screen text-violet-dark dark:text-beige">
 			<BackgroundGradient />
 			<main className="relative z-10 max-w-4xl mx-auto px-6 py-20" role="main">
 				<motion.div
@@ -20,10 +20,11 @@ export default function LegalNotice() {
 					<FadeInUp delay={0.2}>
 						<Link 
 							to="/" 
-							className="mb-8 px-4 py-2 rounded-full bg-orange/10 text-orange-dark border border-orange/20
-							hover:bg-orange hover:text-beige transition-all duration-300 
+							className="mb-8 px-4 py-2 rounded-full bg-orange/10 text-orange-dark dark:text-orange border border-orange/20
+							hover:bg-orange hover:text-beige dark:hover:bg-orange/20 dark:hover:text-orange
+							transition-all duration-300
 							inline-flex items-center gap-2 font-medium text-sm
-							hover:shadow-md hover:scale-105 active:scale-95 focus:outline-none focus:ring-2 focus:ring-orange focus:ring-offset-2"
+							hover:shadow-md hover:scale-105 active:scale-95 focus:outline-none focus:ring-2 focus:ring-orange focus:ring-offset-2 dark:focus:ring-offset-dark-bg"
 							aria-label={t('common:buttons.backToHome')}
 						>
 							<FaArrowLeft className="inline-block" /> {t('common:buttons.backToHome')}
@@ -31,7 +32,7 @@ export default function LegalNotice() {
 					</FadeInUp>
 
 					<FadeInUp delay={0.4}>
-						<h1 className="text-4xl md:text-5xl font-display font-extrabold mb-8 text-violet">
+						<h1 className="text-4xl md:text-5xl font-display font-extrabold mb-8 text-violet dark:text-beige">
 							{t('legalNotice.title')}
 						</h1>
 					</FadeInUp>
@@ -55,7 +56,7 @@ export default function LegalNotice() {
 								<p>
 									<strong>{t('legalNotice.hosting.provider')}</strong><br />
 									{t('legalNotice.hosting.address')}<br />
-									<a href={t('legalNotice.hosting.website')} className="text-orange-dark hover:underline" target="_blank" rel="noopener noreferrer">
+									<a href={t('legalNotice.hosting.website')} className="text-orange-dark dark:text-orange hover:underline" target="_blank" rel="noopener noreferrer">
 										{t('legalNotice.hosting.website')}
 									</a>
 								</p>

--- a/src/pages/privacy-policy.tsx
+++ b/src/pages/privacy-policy.tsx
@@ -11,7 +11,7 @@ export default function PrivacyPolicy() {
 	const sections = t('privacy.sections', { returnObjects: true }) as Record<string, { title: string; content: string[] }>;
 
 	return (
-		<div className="min-h-screen text-violet-dark">
+		<div className="min-h-screen text-violet-dark dark:text-beige">
 			<BackgroundGradient />
 			<main className="relative z-10 max-w-4xl mx-auto px-6 py-20" role="main">
 				<motion.div
@@ -22,10 +22,11 @@ export default function PrivacyPolicy() {
 					<FadeInUp delay={0.2}>
 						<Link 
 							to="/" 
-							className="mb-8 px-4 py-2 rounded-full bg-orange/10 text-orange-dark border border-orange/20
-							hover:bg-orange hover:text-beige transition-all duration-300 
+							className="mb-8 px-4 py-2 rounded-full bg-orange/10 text-orange-dark dark:text-orange border border-orange/20
+							hover:bg-orange hover:text-beige dark:hover:bg-orange/20 dark:hover:text-orange
+							transition-all duration-300
 							inline-flex items-center gap-2 font-medium text-sm
-							hover:shadow-md hover:scale-105 active:scale-95 focus:outline-none focus:ring-2 focus:ring-orange focus:ring-offset-2"
+							hover:shadow-md hover:scale-105 active:scale-95 focus:outline-none focus:ring-2 focus:ring-orange focus:ring-offset-2 dark:focus:ring-offset-dark-bg"
 							aria-label={t('common:buttons.backToHome')}
 						>
 							<FaArrowLeft className="inline-block" /> {t('common:buttons.backToHome')}
@@ -33,7 +34,7 @@ export default function PrivacyPolicy() {
 					</FadeInUp>
 
 					<FadeInUp delay={0.4}>
-						<h1 className="text-4xl md:text-5xl font-display font-extrabold mb-8 text-violet">
+						<h1 className="text-4xl md:text-5xl font-display font-extrabold mb-8 text-violet dark:text-beige">
 							{t('privacy.title')}
 						</h1>
 					</FadeInUp>

--- a/src/pages/project-detail.tsx
+++ b/src/pages/project-detail.tsx
@@ -12,13 +12,13 @@ import SeoHead from "@/components/common/seo-head";
 const getStatusColor = (status: Project['status']) => {
 	switch (status) {
 		case 'completed':
-			return 'bg-lime text-violet-dark';
+			return 'bg-lime text-violet-dark dark:bg-lime/20 dark:text-lime';
 		case 'in-progress':
-			return 'bg-orange text-white';
+			return 'bg-orange text-white dark:bg-orange/20 dark:text-orange';
 		case 'concept':
-			return 'bg-violet text-white';
+			return 'bg-violet text-white dark:bg-violet/40 dark:text-beige';
 		default:
-			return 'bg-violet text-white';
+			return 'bg-violet text-white dark:bg-violet/40 dark:text-beige';
 	}
 };
 
@@ -43,10 +43,10 @@ export default function ProjectDetail() {
 
 	if (!project) {
 		return (
-			<div className="min-h-screen flex items-center justify-center text-violet">
+			<div className="min-h-screen flex items-center justify-center text-violet dark:text-beige">
 				<div className="text-center">
 					<h1 className="text-4xl font-bold mb-4">{t('projects:errors.notFound')}</h1>
-					<Link to="/" className="text-orange-dark hover:text-violet underline">
+					<Link to="/" className="text-orange-dark dark:text-orange hover:text-violet dark:hover:text-lime underline">
 						{t('projects:errors.backToHome')}
 					</Link>
 				</div>
@@ -65,7 +65,7 @@ export default function ProjectDetail() {
 				ogImage={`https://josuerocha.dev${project.image.desktop}`}
 				canonical={`https://josuerocha.dev/projet/${project.id}`}
 			/>
-			<div className="min-h-screen text-violet">
+			<div className="min-h-screen text-violet dark:text-beige">
 				<BackgroundGradient />
 				<main className="relative z-10 max-w-6xl mx-auto px-6 py-20" role="main">
 					<motion.div
@@ -76,10 +76,11 @@ export default function ProjectDetail() {
 					<FadeInUp delay={0.2}>
 						<button
 							onClick={() => navigate(-1)}
-							className="mb-8 px-4 py-2 rounded-full bg-orange/10 text-orange-dark border border-orange/20
-							hover:bg-orange hover:text-beige transition-all duration-300 
+							className="mb-8 px-4 py-2 rounded-full bg-orange/10 text-orange-dark dark:text-orange border border-orange/20
+							hover:bg-orange hover:text-beige dark:hover:bg-orange/20 dark:hover:text-orange
+							transition-all duration-300
 							inline-flex items-center gap-2 font-medium text-sm
-							hover:shadow-md hover:scale-105 active:scale-95 focus:outline-none focus:ring-2 focus:ring-orange focus:ring-offset-2"
+							hover:shadow-md hover:scale-105 active:scale-95 focus:outline-none focus:ring-2 focus:ring-orange focus:ring-offset-2 dark:focus:ring-offset-dark-bg"
 							aria-label={t('projects:actions.backToProjects')}
 							type="button"
 						>
@@ -111,7 +112,7 @@ export default function ProjectDetail() {
 									<h1 className="text-4xl md:text-5xl font-display font-extrabold mb-4">
 										{project.title}
 									</h1>
-									<div className="flex items-center gap-4 text-violet/80 mb-6">
+									<div className="flex items-center gap-4 text-violet/80 dark:text-beige/70 mb-6">
 										<span className="flex items-center gap-2">
 											<FaCalendar />
 											{project.year}
@@ -127,7 +128,7 @@ export default function ProjectDetail() {
 							<FadeInUp delay={0.8}>
 								<div>
 									<h2 className="text-2xl font-bold mb-4">{t('projects:labels.description')}</h2>
-									<p className="text-lg leading-relaxed text-violet/90">
+									<p className="text-lg leading-relaxed text-violet/90 dark:text-beige/80">
 										{t(`projects:items.${project.id}.description`, { defaultValue: project.description })}
 									</p>
 								</div>
@@ -136,7 +137,7 @@ export default function ProjectDetail() {
 							<FadeInUp delay={1.0}>
 								<div>
 									<h2 className="text-2xl font-bold mb-4">{t('projects:labels.deliverables')}</h2>
-									<p className="text-lg leading-relaxed text-violet/90">
+									<p className="text-lg leading-relaxed text-violet/90 dark:text-beige/80">
 										{t(`projects:items.${project.id}.deliverables`, { defaultValue: project.deliverables })}
 									</p>
 								</div>
@@ -145,7 +146,7 @@ export default function ProjectDetail() {
 							<FadeInUp delay={1.2}>
 								<div>
 									<h2 className="text-2xl font-bold mb-4">{t('projects:labels.context')}</h2>
-									<p className="text-lg leading-relaxed text-violet/90">
+									<p className="text-lg leading-relaxed text-violet/90 dark:text-beige/80">
 										{t(`projects:items.${project.id}.context`, { defaultValue: project.context })}
 									</p>
 								</div>
@@ -159,7 +160,7 @@ export default function ProjectDetail() {
 											{project.technologies.map((tech, index) => (
 												<span
 													key={index}
-													className="px-3 py-1 bg-lime/20 text-violet border border-lime/30 rounded-full text-sm font-medium"
+													className="px-3 py-1 bg-lime/20 dark:bg-lime/10 text-violet dark:text-beige border border-lime/30 dark:border-lime/20 rounded-full text-sm font-medium"
 												>
 													{tech}
 												</span>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,6 +1,7 @@
 import type { Config } from "tailwindcss";
 
 const config: Config = {
+	darkMode: 'class',
 	content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
 	theme: {
 		extend: {
@@ -11,6 +12,9 @@ const config: Config = {
 			'orange-dark': '#C56200',
 			violet: '#6900FF',
 			'violet-dark': '#5500CC', // Better contrast for text on light backgrounds
+			// Dark mode surface colors
+			'dark-bg': '#0F0A1A',
+			'dark-surface': '#1A1230',
 		  },
 		  fontFamily: {
 			sans: ['Rubik', 'sans-serif'],


### PR DESCRIPTION
## Summary
- **ThemeToggle** component (sun/moon, Framer Motion animation) fixed top-left, available on all pages
- **useTheme** hook: localStorage persistence + `prefers-color-scheme` fallback + OS preference listener
- **Anti-flash script** in `<head>` to prevent white flash on dark-preferring users
- **Tailwind `darkMode: 'class'`** strategy with `dark-bg` (#0F0A1A) and `dark-surface` (#1A1230) palette
- **All components adapted**: `dark:` variants on text, backgrounds, borders, cards, buttons, hover states
- **Decorative elements**: sun SVG, hand image, smiles, layered icons — opacity reduced via wrapper divs (Framer Motion inline style compat)
- **i18n**: theme labels added in fr/en/pt
- **Meta theme-color** updated dynamically for mobile browsers
- Light palette and existing animations **untouched**

## Test plan
- [ ] Toggle light/dark via the sun/moon button (top-left)
- [ ] Verify preference persists after page reload (localStorage)
- [ ] Remove localStorage `theme` key, set OS to dark — should auto-detect
- [ ] Check all sections in dark mode: hero, bio, timeline, projects, skills, contact, footer
- [ ] Check secondary pages: project detail, legal notice, privacy policy, 404
- [ ] Verify no flash of white on page load when dark mode is active
- [ ] Verify light mode is visually identical to before this PR
- [ ] Check WCAG contrast: beige text on dark background, orange/lime accents
- [ ] Test on mobile (responsive + meta theme-color)

🤖 Generated with [Claude Code](https://claude.com/claude-code)